### PR TITLE
Add frame_id to wrench publisher

### DIFF
--- a/ros_pybullet_interface/src/rpbi/pybullet_robot_joints.py
+++ b/ros_pybullet_interface/src/rpbi/pybullet_robot_joints.py
@@ -83,7 +83,7 @@ class Joint:
         self.pb_obj.pb.enableJointForceTorqueSensor(self.pb_obj.body_unique_id, self.jointIndex, enableSensor=1)
         self.ft_pub_key = f'{self.pb_obj.name}_{self.jointName}_ft_sensor'
         self.pb_obj.pubs[self.ft_pub_key] = self.pb_obj.node.Publisher(f'rpbi/{self.pb_obj.name}/{self.jointName}/ft_sensor', WrenchStamped, queue_size=10)
-        self.pb_obj.srvs[self.ft_pub_key] = self.pb_obj.node.Service(f'rpbi/{self.pb_obj.name}/{self.jointName}/ft_sensor', Empty, self.zero_wrench)
+        self.pb_obj.srvs[self.ft_pub_key] = self.pb_obj.node.Service(f'rpbi/{self.pb_obj.name}/{self.jointName}/Zero', Empty, self.zero_wrench)
 
     @property
     def ft_sensor_enabled(self):

--- a/ros_pybullet_interface/src/rpbi/pybullet_robot_joints.py
+++ b/ros_pybullet_interface/src/rpbi/pybullet_robot_joints.py
@@ -80,9 +80,10 @@ class Joint:
     def ft_sensor_enabled(self):
         return self.ft_pub_key is not None
 
-    def publish_wrench(self, joint_reaction_forces):
+    def publish_wrench(self, joint_reaction_forces, frame_id):
         msg = WrenchStamped()
         msg.header.stamp = self.pb_obj.node.time_now()
+        msg.header.frame_id = frame_id
         msg.wrench.force.x = joint_reaction_forces[0]
         msg.wrench.force.y = joint_reaction_forces[1]
         msg.wrench.force.z = joint_reaction_forces[2]
@@ -270,7 +271,7 @@ class Joints(list):
         # Publish ft sensor states
         for joint, joint_state in zip(self, joint_states):
             if joint.ft_sensor_enabled:
-                joint.publish_wrench(joint_state[2])
+                joint.publish_wrench(joint_state[2], joint.linkName)
 
         # Publish joint state message
         self.pb_obj.pubs['joint_state'].publish(self.pack_joint_state_msg(joint_states))

--- a/ros_pybullet_interface/src/rpbi/pybullet_robot_joints.py
+++ b/ros_pybullet_interface/src/rpbi/pybullet_robot_joints.py
@@ -84,12 +84,12 @@ class Joint:
         msg = WrenchStamped()
         msg.header.stamp = self.pb_obj.node.time_now()
         msg.header.frame_id = frame_id
-        msg.wrench.force.x = joint_reaction_forces[0]
-        msg.wrench.force.y = joint_reaction_forces[1]
-        msg.wrench.force.z = joint_reaction_forces[2]
-        msg.wrench.torque.x = joint_reaction_forces[3]
-        msg.wrench.torque.y = joint_reaction_forces[4]
-        msg.wrench.torque.z = joint_reaction_forces[5]
+        msg.wrench.force.x = -joint_reaction_forces[0]
+        msg.wrench.force.y = -joint_reaction_forces[1]
+        msg.wrench.force.z = -joint_reaction_forces[2]
+        msg.wrench.torque.x = -joint_reaction_forces[3]
+        msg.wrench.torque.y = -joint_reaction_forces[4]
+        msg.wrench.torque.z = -joint_reaction_forces[5]
         self.pb_obj.pubs[self.ft_pub_key].publish(msg)
 
 class Joints(list):


### PR DESCRIPTION
This is just a small change to add frame_id when publishing the wrenches.

We need this in order to visualize (in rviz) the frame where the wrench applies to.

Just check and comment, do not merge it yet.
From the visualization i think that the force signs are reversed.
I'll check that tomorrow with the robot to make sure it's correct.

What i mean is, in order to be consistent with a force sensor on a robot, it should read as the force is being externally applied.
For me it seems that it is outputting the internal force instead, which is not what we want. But let me confirm this better.