### PR TITLE
Add set dynamics srv

### DIFF
--- a/ros_pybullet_interface/CMakeLists.txt
+++ b/ros_pybullet_interface/CMakeLists.txt
@@ -31,6 +31,7 @@ add_service_files(
   GetDebugVisualizerCamera.srv
   AddPybulletObject.srv
   GetObjectDynamics.srv
+  ChangeObjectDynamics.srv
 )
 
 generate_messages(

--- a/ros_pybullet_interface/CMakeLists.txt
+++ b/ros_pybullet_interface/CMakeLists.txt
@@ -17,6 +17,7 @@ add_message_files(
   JointInfo.msg
   CalculateInverseKinematicsProblem.msg
   PybulletObject.msg
+  ObjectDynamics.msg
   KeyboardEvent.msg
   MouseEvent.msg
 )
@@ -29,6 +30,7 @@ add_service_files(
   CalculateInverseKinematics.srv
   GetDebugVisualizerCamera.srv
   AddPybulletObject.srv
+  GetObjectDynamics.srv
 )
 
 generate_messages(

--- a/ros_pybullet_interface/msg/ObjectDynamics.msg
+++ b/ros_pybullet_interface/msg/ObjectDynamics.msg
@@ -1,0 +1,12 @@
+float64 mass
+float64 lateral_friction
+float64[] local_inertia_diagonal
+float64[] local_inertia_pos
+float64[] local_inertia_orn
+float64 restitution
+float64 rolling_friction
+float64 spinning_friction
+float64 contact_damping
+float64 contact_stiffness
+uint64 body_type
+float64 collision_margin

--- a/ros_pybullet_interface/msg/ObjectDynamics.msg
+++ b/ros_pybullet_interface/msg/ObjectDynamics.msg
@@ -1,12 +1,9 @@
 float64 mass
 float64 lateral_friction
 float64[] local_inertia_diagonal
-float64[] local_inertia_pos
-float64[] local_inertia_orn
 float64 restitution
 float64 rolling_friction
 float64 spinning_friction
 float64 contact_damping
 float64 contact_stiffness
-uint64 body_type
 float64 collision_margin

--- a/ros_pybullet_interface/scripts/ros_pybullet_interface_node.py
+++ b/ros_pybullet_interface/scripts/ros_pybullet_interface_node.py
@@ -206,17 +206,14 @@ class Node(RosNode):
 
         object_dynamics_msg = ObjectDynamics()
         object_dynamics_msg.mass = object_dynamics['mass']
-        object_dynamics_msg.lateral_friction = object_dynamics['lateral friction']
-        object_dynamics_msg.local_inertia_diagonal = object_dynamics['local inertia diagonal']
-        object_dynamics_msg.local_inertia_pos = object_dynamics['local inertia pos']
-        object_dynamics_msg.local_inertia_orn = object_dynamics['local inertia orn']
+        object_dynamics_msg.lateral_friction = object_dynamics['lateralFriction']
+        object_dynamics_msg.local_inertia_diagonal = object_dynamics['localInertiaDiagonal']
         object_dynamics_msg.restitution = object_dynamics['restitution']
-        object_dynamics_msg.rolling_friction = object_dynamics['rolling friction']
-        object_dynamics_msg.spinning_friction = object_dynamics['spinning friction']
-        object_dynamics_msg.contact_damping = object_dynamics['contact damping']
-        object_dynamics_msg.contact_stiffness = object_dynamics['contact stiffness']
-        object_dynamics_msg.body_type = object_dynamics['body type']
-        object_dynamics_msg.collision_margin = object_dynamics['collision margin']
+        object_dynamics_msg.rolling_friction = object_dynamics['rollingFriction']
+        object_dynamics_msg.spinning_friction = object_dynamics['spinningFriction']
+        object_dynamics_msg.contact_damping = object_dynamics['contactDamping']
+        object_dynamics_msg.contact_stiffness = object_dynamics['contactStiffness']
+        object_dynamics_msg.collision_margin = object_dynamics['collisionMargin']
 
         return GetObjectDynamicsResponse(success=success, message=message, object_dynamics=object_dynamics_msg)
 

--- a/ros_pybullet_interface/src/rpbi/pybullet_object.py
+++ b/ros_pybullet_interface/src/rpbi/pybullet_object.py
@@ -68,6 +68,28 @@ class PybulletObject(ABC):
             config['activationState'] = getattr(self.pb, config['activationState'])
         self.pb.changeDynamics(**config)
 
+    def get_dynamics(self, link_index=-1):
+        """Exposes changeDynamics."""
+        config = {}
+        config['bodyUniqueId'] = self.body_unique_id
+        config['linkIndex'] = link_index
+        dynamics_info = self.pb.getDynamicsInfo(**config)
+        dynamics_dict = {
+            "mass": dynamics_info[0],
+            "lateral friction": dynamics_info[1],
+            "local inertia diagonal": dynamics_info[2],
+            "local inertia pos": dynamics_info[3],
+            "local inertia orn": dynamics_info[4],
+            "restitution": dynamics_info[5],
+            "rolling friction": dynamics_info[6],
+            "spinning friction": dynamics_info[7],
+            "contact damping": dynamics_info[8],
+            "contact stiffness": dynamics_info[9],
+            "body type": dynamics_info[10],
+            "collision margin": dynamics_info[11]
+        }
+        return dynamics_dict
+
 
     def destroy(self):
         """Removes the object from Pybullet and closes any communication with ROS."""
@@ -84,7 +106,6 @@ class PybulletObject(ABC):
 
         # Remove object from pybullet
         self.pb.removeBody(self.body_unique_id)
-
 
 class PybulletObjectArray:
 

--- a/ros_pybullet_interface/src/rpbi/pybullet_object.py
+++ b/ros_pybullet_interface/src/rpbi/pybullet_object.py
@@ -76,17 +76,14 @@ class PybulletObject(ABC):
         dynamics_info = self.pb.getDynamicsInfo(**config)
         dynamics_dict = {
             "mass": dynamics_info[0],
-            "lateral friction": dynamics_info[1],
-            "local inertia diagonal": dynamics_info[2],
-            "local inertia pos": dynamics_info[3],
-            "local inertia orn": dynamics_info[4],
+            "lateralFriction": dynamics_info[1],
+            "localInertiaDiagonal": dynamics_info[2],
             "restitution": dynamics_info[5],
-            "rolling friction": dynamics_info[6],
-            "spinning friction": dynamics_info[7],
-            "contact damping": dynamics_info[8],
-            "contact stiffness": dynamics_info[9],
-            "body type": dynamics_info[10],
-            "collision margin": dynamics_info[11]
+            "rollingFriction": dynamics_info[6],
+            "spinningFriction": dynamics_info[7],
+            "contactDamping": dynamics_info[8],
+            "contactStiffness": dynamics_info[9],
+            "collisionMargin": dynamics_info[11]
         }
         return dynamics_dict
 

--- a/ros_pybullet_interface/srv/ChangeObjectDynamics.srv
+++ b/ros_pybullet_interface/srv/ChangeObjectDynamics.srv
@@ -1,0 +1,5 @@
+string object_name
+ros_pybullet_interface/ObjectDynamics object_dynamics
+---
+bool success
+string message

--- a/ros_pybullet_interface/srv/GetObjectDynamics.srv
+++ b/ros_pybullet_interface/srv/GetObjectDynamics.srv
@@ -1,0 +1,5 @@
+string object_name
+---
+bool success
+string message
+ros_pybullet_interface/ObjectDynamics object_dynamics


### PR DESCRIPTION
This adds two ros services for:
- get pybullet object dynamics
- change pybullet object dynamics

Note that we exposed only the dynamic properties that we can both read and write using pybullet.
This was such that the message for getting and changing the parameters would be the same.
If we want to allow the user to get and change different sets of parameters, we have to think about different message system.